### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/martinams/94ca55f8-6a9a-419b-9d3c-50e59e70e430/efd02c36-a3fd-4557-8408-04324cff62e6/_apis/work/boardbadge/04c9353f-106f-4703-80a2-e9217ab10eb8)](https://dev.azure.com/martinams/94ca55f8-6a9a-419b-9d3c-50e59e70e430/_boards/board/t/efd02c36-a3fd-4557-8408-04324cff62e6/Microsoft.RequirementCategory)
 # Welcome to GitHub
 
 Welcome to GitHub—where millions of developers work together on software. Ready to get started? Let’s learn how this all works by building and publishing your first GitHub Pages website!


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/martinams/94ca55f8-6a9a-419b-9d3c-50e59e70e430/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.